### PR TITLE
fix: NaN sum if evict all and add back element

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Scan the code
-      run: /osv-scanner -r --skip-git . || if [ $? -eq 128 ]; then true; else exit $?; fi
+      run: /osv-scanner -r . || if [ $? -eq 128 ]; then true; else exit $?; fi
   golangci-lint:
     name: Run golangci-lint
     runs-on: ubuntu-latest

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -6,3 +6,6 @@ reason = "not applicable"
 id = "GO-2023-2186"
 reason = "not applicable"
 
+[[IgnoredVulns]]
+id = "GO-2025-3750"
+reason = "not applicable"

--- a/rolling.go
+++ b/rolling.go
@@ -110,12 +110,7 @@ func (w *Window) AddAt(value float64, at time.Time) {
 	}
 
 	w.cnt++
-
-	if w.cnt == 1 {
-		w.sum = value
-	} else {
-		w.sum += value
-	}
+	w.sum += value
 
 	// Remove head if window is full.
 	if w.cnt > w.maxSize {
@@ -162,7 +157,7 @@ func (w *Window) Evict() {
 	}
 
 	if w.cnt == 0 {
-		w.sum = math.NaN()
+		w.sum = 0
 		w.min = math.MaxFloat64
 		w.max = -math.MaxFloat64
 	}

--- a/rolling.go
+++ b/rolling.go
@@ -110,7 +110,12 @@ func (w *Window) AddAt(value float64, at time.Time) {
 	}
 
 	w.cnt++
-	w.sum += value
+
+	if w.cnt == 1 {
+		w.sum = value
+	} else {
+		w.sum += value
+	}
 
 	// Remove head if window is full.
 	if w.cnt > w.maxSize {

--- a/rolling_test.go
+++ b/rolling_test.go
@@ -292,6 +292,16 @@ func TestFuzz(t *testing.T) {
 	}
 }
 
+func TestEvictAllAndAddAgain(t *testing.T) {
+	w := NewWindow(3, time.Millisecond*100)
+	w.AddAt(rand.Float64(), time.Now().Add(-time.Hour))
+	w.Evict()
+	w.Add(10.0)
+	if w.Sum() != 10.0 {
+		t.Errorf("expected sum 10, but got %f", w.Sum())
+	}
+}
+
 func TestEvictAddAtOutOfOrder(t *testing.T) {
 	w := NewWindow(100, time.Millisecond*100)
 	before := runtime.MemStats{}


### PR DESCRIPTION
When `Evict` removes the last element from the `Window`, it sets `w.sum` to `math.NaN`.
This in turn makes counter to stuck at `NaN` forever, as increment of `w.sum += value` always yields `NaN`.

This PR changes `Evict` logic to set `w.sum = 0` when all values are evicted (this is consistent with default state of empty `Window` created by `NewWindow`) and avoids the `NaN` issue altogether.